### PR TITLE
Add fetching of compiled schema fixtures

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
   },
   "extends": "eslint:recommended",
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "ecmaVersion": 2017
   },
   "rules": {
     "indent": [

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,8 @@ install:
   - yarn --version
   - yarn install
 
-before_build:
-  - yarn lint
-
 build_script:
+  - yarn lint
   - yarn build
 
 test_script:

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,0 +1,70 @@
+import which from 'which';
+import {execFile} from 'child_process';
+
+/**
+ * An error that can occur when the compilation of a schema file fails
+ * @param {String} message the error message that was returned from the compiler
+ * @param {Integer} code the status code returned from the compiler
+ */
+export class CompilationError extends Error {
+  constructor(message, code) {
+    super(message);
+    Object.defineProperties(this, {
+      code: {value: code}
+    });
+  }
+}
+
+/**
+ * Finds the Cap'n Proto compiler
+ * @param {String} exe the location of the Cap'n Proto compiler to use
+ * @throws {CompilationError} when the compiler cannot be found
+ * @returns {Promise<String>} the location of the compiler
+ */
+export function compiler(exe=null) {
+  return new Promise((resolve, reject) => {
+    if (exe) {
+      resolve(exe);
+    } else {
+      which('capnp', (err, exe) => {
+        if (err) {
+          reject(new CompilationError('Failed to find the Cap\'n Proto compiler', -199));
+        } else {
+          resolve(exe);
+        }
+      });
+    }
+  });
+}
+
+/**
+ * Performs compilation of a Cap'n Proto file into it's binary representation
+ * @param {String} executable the location of the Cap'n Proto compiler to use
+ * @param {String} schema the location of the schema file on the system
+ * @throws {CompilationError} when the compilation fails
+ * @returns {Promise<ArrayBuffer>} the location of the compiled file
+ */
+function compile(executable, schema) {
+  return new Promise((resolve, reject) => {
+    execFile(executable, ['compile', '-o-', schema], {encoding: 'buffer'}, (err, stdout, stderr) => {
+      if (err) {
+        reject(new CompilationError(`Failed to compile: ${stderr}`, err.code));
+      } else {
+        resolve(stdout.buffer);
+      }
+    });
+  });
+}
+
+/**
+ * Compiles a Cap'n Proto schema file using the compiler
+ * @async
+ * @param {String} schema the location of the schema file on the system
+ * @param {String} exe the location of the Cap'n Proto compiler to use
+ * @throws {CompilationError} when the compilation fails
+ * @returns {Promise<String>} the location of the compiled file
+ */
+export default async function(schema, exe=null) {
+  const executable = await compiler(exe);
+  return await compile(executable, schema);
+}

--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
     "documentation": "^5.3.1",
     "eslint": "^4.6.1",
     "mocha": "^3.5.3",
+    "node-fetch": "^2.0.0-alpha.9",
     "nyc": "^11.2.1",
     "rollup": "^0.49.3",
-    "rollup-plugin-babel": "^3.0.2"
+    "rollup-plugin-babel": "^3.0.2",
+    "which": "^1.3.0"
   },
   "scripts": {
     "distclean": "git clean -xfd",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "nyc": "^11.2.1",
     "rollup": "^0.49.3",
     "rollup-plugin-babel": "^3.0.2",
+    "whatwg-url": "^6.3.0",
     "which": "^1.3.0"
   },
   "scripts": {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "globals": {
-    "should": false
+    "fetchSchema": false
   },
   "env": {
     "mocha": true

--- a/test/fetchSchema.js
+++ b/test/fetchSchema.js
@@ -1,0 +1,35 @@
+/**
+ * Reports an error when fetching a URL
+ * @param {String} message the error message for the error
+ * @param {Response} response the result of the fetch request
+ */
+export class FetchError extends Error {
+  constructor(message, response) {
+    super(message);
+    Object.defineProperties(this, {
+      response: {value: response}
+    });
+  }
+}
+
+/**
+ * Fetches a compiled schema file
+ * @async
+ * @param {String} schema the schema file to load from the fixtures directory
+ * @throws {FetchError} when the fetching of the compiled schema fails
+ * @returns {Promise<ArrayBuffer>} the compiled binary data
+ */
+export default async function(schema) {
+  const headers = new Headers({'Accept': 'application/x-capnp-schema-binary'});
+  const response = await fetch(`${location.origin}/${schema}`, {headers});
+
+  if (!response.ok) {
+    const json = await response.json();
+    const {error} = json;
+    throw new FetchError(error, response);
+  }
+
+  return await response.arrayBuffer();
+}
+
+

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -2,7 +2,11 @@ import chai from 'chai';
 import {URL} from 'url';
 import babelRegister from 'babel-register';
 import fs from 'fs';
+import http from 'http';
 import path from 'path';
+import fetch, {Headers, Request, Response} from 'node-fetch';
+import compile, {compiler} from '../lib/compile.js';
+import fetchSchema from './fetchSchema.js';
 
 const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json')));
 const babelrc = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '.babelrc')));
@@ -10,6 +14,52 @@ const ignoreRegexp = new RegExp(`node_modules/(?!${Object.keys(pkg.dependencies 
 const options = Object.assign(babelrc, {ignore: (filename) => filename.match(ignoreRegexp), babelrc: false});
 babelRegister(options);
 
+const port = 58956;
+
 global.chai = chai;
 global.should = chai.should();
 global.URL = URL;
+global.fetch = fetch;
+global.fetchSchema = fetchSchema;
+global.Headers = Headers;
+global.Request = Request;
+global.Response = Response;
+global.location = {
+  origin: `http://localhost:${port}`
+};
+
+function handleRequest(request, response) {
+  const {accept} = request.headers;
+  if (['application/x-capnp-schema-binary', 'application/*', '*/*'].indexOf(accept) === -1) {
+    response.writeHead(406, {'Content-Type': 'application/json'});
+    response.end(JSON.stringify({error: `Invalid accepts: ${accept}`}));
+  }
+
+  const url = new URL(`${location.origin}${request.url}`);
+  compiler()
+    .catch(err => {
+      response.writeHead(501, {'Content-Type': 'application/json'});
+      response.end(JSON.stringify({error: `Failed to find compiler: ${err}`}));
+    })
+    .then(executable => {
+      return compile(path.join(__dirname, 'fixtures', url.pathname), executable)
+        .then(schema => {
+          response.writeHead(200, {'Content-Type': 'application/x-capnp-schema-binary'});
+          response.end(Buffer.from(schema, 0, schema.length));
+        })
+        .catch(err => {
+          response.writeHead(500, {'Content-Type': 'application/json'});
+          response.end(JSON.stringify({error: `Failed to compile schema: ${err.message}`}));
+        });
+    });
+}
+
+before(function(done) {
+  this.port = port;
+  this.server = http.createServer(handleRequest);
+  this.server.listen(this.port, done);
+});
+
+after(function(done) {
+  this.server.close(done);
+});

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import {URL} from 'url';
+import {URL} from 'whatwg-url';
 import babelRegister from 'babel-register';
 import fs from 'fs';
 import http from 'http';

--- a/test/spec/main.js
+++ b/test/spec/main.js
@@ -1,4 +1,15 @@
 import '../../lib/main.js';
 
 describe('main', () => {
+  before(function() {
+    return fetchSchema('Id.capnp').catch(err => {
+      if (err.response.status === 501) {
+        this.skip();
+      }
+    });
+  });
+
+  it('can download of a compiled schema file', () => {
+    return fetchSchema('Id.capnp');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2925,6 +2925,10 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
 lodash@^4.0.0, lodash@^4.11.1, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -3609,6 +3613,10 @@ pseudomap@^1.0.2:
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 qs@^6.4.0:
   version "6.5.1"
@@ -4517,6 +4525,12 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
+tr46@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
+
 trim-lines@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.0.tgz#9926d03ede13ba18f7d42222631fb04c79ff26fe"
@@ -4780,6 +4794,10 @@ vinyl@^2.0.0:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
+webidl-conversions@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
 websocket-driver@>=0.5.1:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb"
@@ -4790,6 +4808,14 @@ websocket-driver@>=0.5.1:
 websocket-extensions@>=0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.2.tgz#0e18781de629a18308ce1481650f67ffa2693a5d"
+
+whatwg-url@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.3.0.tgz#597ee5488371abe7922c843397ddec1ae94c048d"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.0"
+    webidl-conversions "^4.0.1"
 
 which-module@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3200,6 +3200,10 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+node-fetch@^2.0.0-alpha.9:
+  version "2.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.0.0-alpha.9.tgz#990c0634f510f76449a0d6f6eaec96b22f273628"
+
 node-pre-gyp@^0.6.36:
   version "0.6.37"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.37.tgz#3c872b236b2e266e4140578fe1ee88f693323a05"
@@ -4795,7 +4799,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.4, which@^1.2.9:
+which@^1.2.4, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
This allows the unit tests to fetch compiled schema files in binary
format to perform unit tests on. This is implemented this way so that
we will be able to perform the same unit tests in the browser. We
ideally want all of our parsing and generation code to work in the
browser so we can auto-generate API code if necessary